### PR TITLE
Show queries under SQL statement tab

### DIFF
--- a/lib/newrelic_moped/instrumentation.rb
+++ b/lib/newrelic_moped/instrumentation.rb
@@ -12,7 +12,8 @@ DependencyDetection.defer do
   executes do
     Moped::Node.class_eval do
       def process_with_newrelic_trace(operation, &callback)
-        self.class.trace_execution_scoped(["Moped/Node/process"]) do
+        collection = operation.collection
+        self.class.trace_execution_scoped(["Moped::process[#{collection}]"]) do
           t0 = Time.now
 
           begin


### PR DESCRIPTION
First commit allows you to see moped queries under 'SQL statement' tab in NewRelic.

Second commit changes format of metrics name from 'Moped/Node/process' to 'Moped::process[DOCUMENT_NAME]' which helps you to identify a slowness easily.
