### PR TITLE
Added several enhancements to how moped commands were being reported

### DIFF
--- a/lib/newrelic_moped/instrumentation.rb
+++ b/lib/newrelic_moped/instrumentation.rb
@@ -13,28 +13,46 @@ DependencyDetection.defer do
 
   executes do
     Moped::Node.class_eval do
-      def process_with_newrelic_trace(operation, &callback)
-        if operation.respond_to?(:collection)
-          collection = operation.collection
+      include NewRelic::Moped::Instrumentation
+      alias_method :logging_without_newrelic_trace, :logging
+      alias_method :logging, :logging_with_newrelic_trace
+    end
+  end
+end
 
-          self.class.trace_execution_scoped(["Moped::process[#{collection}]"]) do
-            t0 = Time.now
+module NewRelic
+  module Moped
+    module Instrumentation
+      def logging_with_newrelic_trace(operations, &blk)
+        operation_name, collection = determine_operation_and_collection(operations.first)
+        log_statement = operations.first.log_inspect
 
-            begin
-              process_without_newrelic_trace(operation, &callback)
-            ensure
-              elapsed_time = (Time.now - t0).to_f
-              NewRelic::Agent.instance.transaction_sampler.notice_sql(operation.log_inspect,
-                                                       nil, elapsed_time)
-              NewRelic::Agent.instance.sql_sampler.notice_sql(operation.log_inspect, nil,
-                                                       nil, elapsed_time)
-            end
-          end
+        self.class.trace_execution_scoped("Database/#{collection}/#{operation_name}") do
+          t0 = Time.now
+          res = logging_without_newrelic_trace(operations, &blk)
+          elapsed_time = (Time.now - t0).to_f
+          NewRelic::Agent.instance.transaction_sampler.notice_sql(log_statement, nil, elapsed_time)
+          NewRelic::Agent.instance.sql_sampler.notice_sql(log_statement, nil, nil, elapsed_time)
+          res
         end
       end
 
-      alias_method :process_without_newrelic_trace, :process
-      alias_method :process, :process_with_newrelic_trace
+      def determine_operation_and_collection(operation)
+        log_statement = operation.log_inspect
+        collection = "Unknown"
+        if operation.respond_to?(:collection)
+          collection = operation.collection
+        end
+        operation_name = log_statement.split[0]
+        if operation_name == 'COMMAND' && log_statement.include?(":mapreduce")
+          operation_name = 'MAPREDUCE'
+          collection = log_statement[/:mapreduce=>"([^"]+)/,1]
+        elsif operation_name == 'COMMAND' && log_statement.include?(":count")
+          operation_name = 'COUNT'
+          collection = log_statement[/:count=>"([^"]+)/,1]
+        end
+        return operation_name, collection
+      end
     end
   end
 end

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -3,6 +3,7 @@ require 'test/unit'
 require 'moped'
 
 require File.expand_path(File.dirname(__FILE__) + '/../lib/newrelic_moped/instrumentation')
+require File.expand_path(File.dirname(__FILE__) + '/moped_command_fake')
 
 class FakeOpWithCollection < Struct.new(:collection, :log_inspect)
 end
@@ -25,7 +26,7 @@ class TestInstrumentation < Test::Unit::TestCase
     @sampler.start_builder
 
     Moped::Node.class_eval do
-      def process_without_newrelic_trace(operation, &callback)
+      def logging_with_newrelic_trace(operations, &callback)
         # do nothing
       end
     end
@@ -41,7 +42,7 @@ class TestInstrumentation < Test::Unit::TestCase
     fake_op = FakeOpWithCollection.new([], "Fake")
 
     assert_nothing_raised do
-      @node.process_with_newrelic_trace(fake_op)
+      @node.logging_with_newrelic_trace(fake_op)
     end
   end
 
@@ -49,7 +50,39 @@ class TestInstrumentation < Test::Unit::TestCase
     fake_op = FakeOpWithoutCollection.new("Fake")
 
     assert_nothing_raised do
-      @node.process_with_newrelic_trace(fake_op) 
+      @node.logging_with_newrelic_trace(fake_op)
     end
+  end
+end
+
+class NewRelicMopedInstrumentationTest < Test::Unit::TestCase
+  include NewRelic::Moped::Instrumentation
+
+  def test_when_command_is_mapreduce
+    command = MopedCommandWithCollectionFake.new("COMMAND database=my_database command={:mapreduce=>\"users\", :query=>{}}", "other_collection")
+    operation, collection = determine_operation_and_collection(command)
+    assert_equal("MAPREDUCE", operation)
+    assert_equal("users", collection, "it should parse collection from statement")
+  end
+
+  def test_query_when_operation_responds_to_collection
+    command = MopedCommandWithCollectionFake.new("QUERY database=my_database collection=xyz", "users")
+    operation, collection = determine_operation_and_collection(command)
+    assert_equal("QUERY", operation)
+    assert_equal("users", collection, "it should use collection from operation")
+  end
+
+  def test_when_command_is_count
+    command = MopedCommandWithCollectionFake.new("COMMAND database=my_database command={:count=>\"users\", query=>{}}", "other_collection")
+    operation, collection = determine_operation_and_collection(command)
+    assert_equal("COUNT", operation)
+    assert_equal("users", collection, "it should parse collection from statement")
+  end
+
+  def test_command_when_operation_does_not_respond_to_collection
+    command = MopedCommandFake.new("COMMAND database=admin command={:ismaster=>1}")
+    operation, collection = determine_operation_and_collection(command)
+    assert_equal("COMMAND", operation)
+    assert_equal("Unknown", collection, "it should set collection name to Unknown")
   end
 end

--- a/test/moped_command_fake.rb
+++ b/test/moped_command_fake.rb
@@ -1,0 +1,27 @@
+
+class MopedCommandFake
+
+  def initialize(log_statement)
+    @log_statement = log_statement
+  end
+
+  def log_inspect
+    @log_statement
+  end
+end
+
+class MopedCommandWithCollectionFake
+
+  def initialize(log_statement, collection)
+    @log_statement = log_statement
+    @collection = collection
+  end
+
+  def log_inspect
+    @log_statement
+  end
+
+  def collection
+    @collection
+  end
+end


### PR DESCRIPTION
If you would like some screens of the operations will be reported in NewRelic, let me know
- Parsing additional details from the operation that allow visibility into the type of command being run (MapReduce, Query, etc) as well as the collection its run against
- Reporting Database commands using the "Database/.." metric to take advantage of NewRelics handling of this key term, and to make custom reports against mongoid easier to create
- By moving to instrumenting the logging call, safe write operations will now be tracked
