### PR TITLE
I've changed the method of listing files in the gem so that it doesn't call a git subprocess.

### DIFF
--- a/newrelic_moped.gemspec
+++ b/newrelic_moped.gemspec
@@ -8,9 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary   = %q{New Relic Instrumentation for Moped & Mongoid 3}
   gem.homepage      = ""
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.files         = Dir["{lib}/**/*.rb", "LICENSE", "*.md"]
   gem.name          = "newrelic_moped"
   gem.require_paths = ["lib"]
   gem.version       = NewrelicMoped::VERSION


### PR DESCRIPTION
Removed unneeded test_files and executables declarations, since those aren't needed in the
installed product.
