### PR TITLE
Include collection and metric in trace details segment names

### DIFF
--- a/lib/newrelic_moped/instrumentation.rb
+++ b/lib/newrelic_moped/instrumentation.rb
@@ -39,7 +39,7 @@ module NewRelic
         res = nil
 
         if metric
-          metrics = ["ActiveRecord/all", "ActiveRecord/#{collection}/#{metric}"]
+          metrics = ["ActiveRecord/#{collection}/#{metric}","ActiveRecord/all"]
 
           self.class.trace_execution_scoped(metrics) do
             t0 = Time.now


### PR DESCRIPTION
The first metric in the metrics array will be used to determine the top level
name for the segment in the trace details view.

When 'ActiveRecord/All' is first the segment name will become 'Database' for all
segments. Changing the order so that 'ActiveRecord/collection/metric' is first
will display the more useful 'collection#metric' as the name for each segment.
