### PR TITLE
Do not explicitly record metrics - trace_execution_scoped will automatically do it

### DIFF
--- a/lib/newrelic_moped/instrumentation.rb
+++ b/lib/newrelic_moped/instrumentation.rb
@@ -52,7 +52,6 @@ module NewRelic
 
                 NewRelic::Agent.instance.transaction_sampler.notice_sql(log_statement, nil, elapsed_time)
                 NewRelic::Agent.instance.sql_sampler.notice_sql(log_statement, metric, nil, elapsed_time)
-                NewRelic::Agent.instance.stats_engine.record_metrics(metrics, elapsed_time)
               end
             end
 


### PR DESCRIPTION
Howdy! First off, thanks for this gem - it's great to see community-supported extensions to newrelic_rpm like this. I work at New Relic and have referred a number of folks looking for Moped instrumentation here. I noticed a bug in the latest version, however that's leading to double-counting of some metrics. Details below from the commit message:

The previous code was double-counting metrics for all queries through Moped,
because of the fact that trace_execution_scoped will automatically record
metrics. The net effect was that the database band on the overview graph in New
Relic was twice as large as it should have been (because the 'ActiveRecord/all'
metric was being recorded twice).

This change removes the additional explicit call to record_metrics (which is not
a public API and may change unpredicatbly) so that metrics are no longer double-counted.
