### PR TITLE
Use and test datastore metrics API, update version, add Mongo to Travis.

### DIFF
--- a/newrelic_moped.gemspec
+++ b/newrelic_moped.gemspec
@@ -13,17 +13,7 @@ Gem::Specification.new do |gem|
   gem.name          = "newrelic_moped"
   gem.require_paths = ["lib"]
   gem.version       = NewrelicMoped::VERSION
-  gem.post_install_message = <<-MESSAGE
-----------------
-IMPORTANT!
-
-This is the last version of newrelic_moped
-supporting newrelic_rpm version < 3.11 !
-
-----------------
-  MESSAGE
-
-  gem.add_dependency 'newrelic_rpm', '>= 3.7', '< 3.11'
+  gem.add_dependency 'newrelic_rpm', '~> 3.11'
   gem.add_dependency 'moped'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Hi @stevebartholomew! Version 3.11 of the Ruby agent includes some features to make instrumenting datastores a bit easier with New Relic. This replaces the previous instrumentation and adds some tests with our test helpers.

Note that your tests now actually use Mongo to test the instrumentation so I've added it as a dependency in your travis.yml file.

Thanks for making New Relic awesome for Moped users, let me know if you have any questions. :smile: 