### PR TITLE
allow newrelic_rpm >= 3.1.1

### DIFF
--- a/newrelic_moped.gemspec
+++ b/newrelic_moped.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.name          = "newrelic_moped"
   gem.require_paths = ["lib"]
   gem.version       = NewrelicMoped::VERSION
-  gem.add_dependency 'newrelic_rpm', '~> 3.11'
+  gem.add_dependency 'newrelic_rpm', '>= 3.11'
   gem.add_dependency 'moped'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Fixes 

Bundler could not find compatible versions for gem "newrelic_rpm":
  In snapshot (Gemfile.lock):
    newrelic_rpm (= 5.1.0.344)

  In Gemfile:
    newrelic_rpm

    newrelic_moped (>= 1.0.1, ~> 1.0) was resolved to 1.0.1, which depends on
      newrelic_rpm (~> 3.11)